### PR TITLE
fix(typography): merging classes when theming

### DIFF
--- a/.changeset/neat-readers-dream.md
+++ b/.changeset/neat-readers-dream.md
@@ -1,0 +1,5 @@
+---
+'@fluwy/ui': patch
+---
+
+Fix theming on typography. Classes are merged instead of replaced when theming typographies.

--- a/src/lib/components/forms/button/button.svelte
+++ b/src/lib/components/forms/button/button.svelte
@@ -2,7 +2,7 @@
     import type { Any, Component } from '@/lib/core/contracts.js';
     import { cn, deferred } from '@/lib/core/utils/index.js';
     import { Icon, type IconProps } from '../../../icon/index.js';
-    import { useClient, useTheme } from '../../../core/client/index.js';
+    import { useClient, mergeThemes } from '../../../core/client/index.js';
     import { useContext } from '../../../core/context/index.js';
     import { type Snippet } from 'svelte';
     import { compile, Render, type ElementProps } from '@/lib/core/index.js';
@@ -32,11 +32,11 @@
     const context = useContext();
     const client = useClient();
 
-    const sizes = useTheme('forms.common.sizes', Sizes);
-    const colors = useTheme('colors', Colors);
-    const variants = useTheme(`forms.${componentName}.variants`, Variants);
-    const defaultSize = useTheme('forms.common.default_size', 'md');
-    const borderRadius = useTheme('forms.common.border_radius', BorderRadius);
+    const sizes = mergeThemes('forms.common.sizes', Sizes);
+    const colors = mergeThemes('colors', Colors);
+    const variants = mergeThemes(`forms.${componentName}.variants`, Variants);
+    const defaultSize = mergeThemes('forms.common.default_size', 'md');
+    const borderRadius = mergeThemes('forms.common.border_radius', BorderRadius);
 
     let innerLoading = false;
 

--- a/src/lib/components/primitives/h1.svelte
+++ b/src/lib/components/primitives/h1.svelte
@@ -14,7 +14,7 @@
     const theme = useTheme('typography.h1', Typography.h1);
 </script>
 
-<h1 class={cn(theme, props.class)}>
+<h1 class={cn(Typography.h1, theme, props.class)}>
     {#if props.content}
         {#if typeof props === 'string'}
             {props}

--- a/src/lib/components/primitives/h2.svelte
+++ b/src/lib/components/primitives/h2.svelte
@@ -14,7 +14,7 @@
     const theme = useTheme('typography.h2', Typography.h2);
 </script>
 
-<h2 class={cn(theme, props.class)}>
+<h2 class={cn(Typography.h2, theme, props.class)}>
     {#if props.content}
         {#if typeof props === 'string'}
             {props}

--- a/src/lib/components/primitives/h3.svelte
+++ b/src/lib/components/primitives/h3.svelte
@@ -14,7 +14,7 @@
     const theme = useTheme('typography.h3', Typography.h3);
 </script>
 
-<h3 class={cn(theme, props.class)}>
+<h3 class={cn(Typography.h3, theme, props.class)}>
     {#if props.content}
         {#if typeof props === 'string'}
             {props}

--- a/src/lib/components/primitives/h4.svelte
+++ b/src/lib/components/primitives/h4.svelte
@@ -14,7 +14,7 @@
     const theme = useTheme('typography.h4', Typography.h4);
 </script>
 
-<h4 class={cn(theme, props.class)}>
+<h4 class={cn(Typography.h4, theme, props.class)}>
     {#if props.content}
         {#if typeof props === 'string'}
             {props}

--- a/src/lib/components/primitives/h5.svelte
+++ b/src/lib/components/primitives/h5.svelte
@@ -14,7 +14,7 @@
     const theme = useTheme('typography.h5', Typography.h5);
 </script>
 
-<h5 class={cn(theme, props.class)}>
+<h5 class={cn(Typography.h5, theme, props.class)}>
     {#if props.content}
         {#if typeof props === 'string'}
             {props}

--- a/src/lib/components/primitives/h6.svelte
+++ b/src/lib/components/primitives/h6.svelte
@@ -14,7 +14,7 @@
     const theme = useTheme('typography.h6', Typography.h6);
 </script>
 
-<h6 class={cn(theme, props.class)}>
+<h6 class={cn(Typography.h6, theme, props.class)}>
     {#if props.content}
         {#if typeof props === 'string'}
             {props}

--- a/src/lib/components/primitives/p.svelte
+++ b/src/lib/components/primitives/p.svelte
@@ -11,10 +11,9 @@
     }
 
     const { children, ...props }: H1Props = $props();
-    const theme = useTheme('typography.p', Typography.p);
 </script>
 
-<h1 class={cn(theme, props.class)}>
+<p class={cn(Typography.p, useTheme('typography.p'), props.class)}>
     {#if props.content}
         {#if typeof props === 'string'}
             {props}
@@ -24,4 +23,4 @@
     {:else if children}
         {@render children()}
     {/if}
-</h1>
+</p>

--- a/src/lib/core/app.svelte
+++ b/src/lib/core/app.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { useClient, useTheme } from './client/index.js';
+    import { useClient, mergeThemes } from './client/index.js';
     import type { RenderResponse } from './contracts.js';
     import Render from './render.svelte';
     import { useDialogs } from './stores/dialogs.js';
@@ -23,7 +23,7 @@
     setContext('context', context);
     setContext('theme', data.theme);
 
-    const colors = useTheme('colors', Colors);
+    const colors = mergeThemes('colors', Colors);
 </script>
 
 <div style={generateColorVariables(colors)}>

--- a/src/lib/core/client/index.ts
+++ b/src/lib/core/client/index.ts
@@ -1,7 +1,7 @@
 import { getContext } from 'svelte';
 import type { Adapter, AdapterData, Any, Context, Operation } from '../contracts.js';
 import { get } from '../utils/index.js';
-import { mergeTheme } from '../utils/merge-theme/index.js';
+import { mergeObjects } from '../utils/merge-objects/index.js';
 
 type OperationName = string;
 type OperationHandlers = {
@@ -15,10 +15,16 @@ export function useClient() {
     return client;
 }
 
-export function useTheme(key: string, defaultValue: Any) {
+export function useTheme(key: string, defaultValue?: Any): Any {
     const theme: Any = getContext('theme');
 
-    return mergeTheme(defaultValue, get(theme, key, defaultValue));
+    return get(theme, key, defaultValue);
+}
+
+export function mergeThemes(key: string, defaultValue: Any) {
+    const theme: Any = getContext('theme');
+
+    return mergeObjects(defaultValue, get(theme, key, defaultValue));
 }
 
 export class Client {

--- a/src/lib/core/utils/merge-objects/index.test.ts
+++ b/src/lib/core/utils/merge-objects/index.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { parse } from 'yaml';
-import { mergeTheme } from './index.js';
+import { mergeObjects } from './index.js';
+import { Typography } from '@/lib/components/primitives/styles.js';
 
 const theme1 = parse(`
 button:
@@ -29,7 +30,7 @@ button:
 
 describe('mergeTheme', () => {
     it('merge two yaml files into one', () => {
-        expect(mergeTheme(theme1, theme2)).toEqual({
+        expect(mergeObjects(theme1, theme2)).toEqual({
             button: {
                 filled: 'text-primary-foreground bg-red-500',
                 outline: 'border border-primary uppercase',
@@ -43,28 +44,28 @@ describe('mergeTheme', () => {
     });
 
     it('throws an error if the values are not of the same type', () => {
-        expect(() => mergeTheme(theme1, wrongTheme)).toThrowError(
+        expect(() => mergeObjects(theme1, wrongTheme)).toThrowError(
             'Property "filled" is of type string but the second one is of type object'
         );
     });
 
     it('return the defined object if one is undefined', () => {
-        expect(mergeTheme(theme1, undefined)).toEqual(theme1);
-        expect(mergeTheme(undefined, theme2)).toEqual(theme2);
+        expect(mergeObjects(theme1, undefined)).toEqual(theme1);
+        expect(mergeObjects(undefined, theme2)).toEqual(theme2);
     });
 
     it('merges nested objects and ignore null values', () => {
-        expect(mergeTheme(theme1, theme2).button.third).toEqual('value');
+        expect(mergeObjects(theme1, theme2).button.third).toEqual('value');
     });
 
     it('merges other values then objects', () => {
-        expect(mergeTheme('md', 'lg')).toEqual('lg');
-        expect(mergeTheme(true, false)).toEqual(false);
-        expect(mergeTheme(10, 12)).toEqual(12);
+        expect(mergeObjects('md', 'lg')).toEqual('lg');
+        expect(mergeObjects(true, false)).toEqual(false);
+        expect(mergeObjects(10, 12)).toEqual(12);
     });
 
     it('doesnt duplicate values', () => {
-        expect(mergeTheme({ primary: '#fff' }, { primary: '#fff' })).toEqual({ primary: '#fff' });
-        expect(mergeTheme({ primary: '#ff1' }, { primary: '#ff2' })).toEqual({ primary: '#ff2' });
+        expect(mergeObjects({ primary: '#fff' }, { primary: '#fff' })).toEqual({ primary: '#fff' });
+        expect(mergeObjects({ primary: '#ff1' }, { primary: '#ff2' })).toEqual({ primary: '#ff2' });
     });
 });

--- a/src/lib/core/utils/merge-objects/index.ts
+++ b/src/lib/core/utils/merge-objects/index.ts
@@ -1,30 +1,30 @@
 import type { Any } from '$lib/core/contracts.js';
 import { cn } from '../index.js';
 
-export function mergeTheme(theme1: Any, theme2: Any) {
+export function mergeObjects(obj1: Any, obj2: Any) {
     const result: Any = {};
     const isUndefined = (value: unknown) => typeof value === 'undefined';
 
-    if (theme1 === theme2) return theme2;
+    if (obj1 === obj2) return obj2;
 
-    if (isUndefined(theme1) || isUndefined(theme2)) {
-        return theme2 ?? theme1;
+    if (isUndefined(obj1) || isUndefined(obj2)) {
+        return obj2 ?? obj1;
     }
 
-    if (typeof theme1 !== typeof theme2) {
-        throw new Error(`Type mismatch on mergeTheme. One is ${typeof theme1} and the other is ${typeof theme2}`);
+    if (typeof obj1 !== typeof obj2) {
+        throw new Error(`Type mismatch on mergeObjects. One is ${typeof obj1} and the other is ${typeof obj2}`);
     }
 
-    if (typeof theme1 !== 'object') {
-        return theme2 ?? theme1;
+    if (typeof obj1 !== 'object') {
+        return obj2 ?? obj1;
     }
 
-    for (const key in theme1) {
-        if (typeof theme2 === 'string') {
-            result[key] = cn(theme1[key], theme2);
-        } else if (key in theme2) {
-            const val1 = theme1[key];
-            const val2 = theme2[key];
+    for (const key in obj1) {
+        if (typeof obj2 === 'string') {
+            result[key] = cn(obj1[key], obj2);
+        } else if (key in obj2) {
+            const val1 = obj1[key];
+            const val2 = obj2[key];
 
             if (val1 === val2) {
                 result[key] = val2;
@@ -32,7 +32,7 @@ export function mergeTheme(theme1: Any, theme2: Any) {
                 const oneOfThemIsColor = isColor(val1) || isColor(val2);
                 result[key] = oneOfThemIsColor ? val2 : cn(val1, val2);
             } else if (typeof val1 === typeof val2 && typeof val1 === 'object') {
-                result[key] = mergeTheme(val1, val2);
+                result[key] = mergeObjects(val1, val2);
             } else if (val1 === null || val2 === null) {
                 result[key] = val1 || val2;
             } else {
@@ -41,13 +41,13 @@ export function mergeTheme(theme1: Any, theme2: Any) {
                 );
             }
         } else {
-            result[key] = theme1[key];
+            result[key] = obj1[key];
         }
     }
 
-    for (const key in theme2) {
-        if (!(key in theme1)) {
-            result[key] = theme2[key];
+    for (const key in obj2) {
+        if (!(key in obj1)) {
+            result[key] = obj2[key];
         }
     }
 


### PR DESCRIPTION
Previously, theme classes for typography was replacing the whole set of default classes which was adding the behaviour of "reseting" the theme for typography whenever user defined the theme for a specific typography. Now the behaviour is to merge those classes defined on the theme for typographies.