### PR TITLE
fix: firefox unsupported dom function

### DIFF
--- a/.changeset/moody-ducks-pull.md
+++ b/.changeset/moody-ducks-pull.md
@@ -1,0 +1,5 @@
+---
+'@fluwy/ui': patch
+---
+
+Fix firefox compatibility issues. Firefox doesn't support `computedStyleMap` function on DOM elements which was breaking fluwy.

--- a/src/lib/components/layouts/page.svelte
+++ b/src/lib/components/layouts/page.svelte
@@ -16,7 +16,9 @@
     const commonBackgroundColor = useCommon('background_color');
 
     function elementIsVisible(element: HTMLElement | null | false) {
-        return Boolean(element && element.computedStyleMap().get('display') !== 'none');
+        if (!element) return false;
+        const style = getComputedStyle(element);
+        return Boolean(style && style.display !== 'none');
     }
 
     const sidebar = $derived(browser && document?.getElementById('sidebar'));

--- a/src/lib/components/layouts/table-of-contents.svelte
+++ b/src/lib/components/layouts/table-of-contents.svelte
@@ -134,7 +134,11 @@
 
     function calculateScrollMarginTop(element: Element): number {
         const headerSize = document.querySelector('#header')?.getBoundingClientRect().height || 0;
-        const currentMarginTop = element.computedStyleMap().get('margin-top')?.toString() || '0';
+
+        if (!element) return headerSize;
+
+        const style = getComputedStyle(element);
+        const currentMarginTop = style.marginBottom || '0';
 
         return headerSize + parseInt(currentMarginTop);
     }


### PR DESCRIPTION
Firefox doesn't support `computedStyleMap` function. We should use `getComputedStyle` instead.