### PR TITLE
Small fixes post release

### DIFF
--- a/.changeset/orange-peas-push.md
+++ b/.changeset/orange-peas-push.md
@@ -1,0 +1,5 @@
+---
+'@fluwy/ui': patch
+---
+
+Add missing handlers for `POST`, `PUT`, `PATCH`, and `DELETE` to the sveltekit's `createProxyApiHandlers` method.

--- a/.changeset/sharp-rabbits-invite.md
+++ b/.changeset/sharp-rabbits-invite.md
@@ -1,0 +1,5 @@
+---
+'@fluwy/ui': patch
+---
+
+Fix how app render was rendering layouts with null values on it. Any null value was being replaced by the body content of the page. Now this is fixed.

--- a/src/lib/components/common/dropdown/dropdown-item.svelte
+++ b/src/lib/components/common/dropdown/dropdown-item.svelte
@@ -5,7 +5,7 @@
     import Icon from '$lib/components/common/icon/icon.svelte';
     import type { IconProps } from '../icon/types.js';
     import { Dropdown } from './styles.js';
-    import type { Any } from '@/lib/core/contracts.js';
+    import type { Any, Operations } from '@/lib/core/contracts.js';
     import { useCommon } from '../styles.js';
     import { useTheme } from '@/lib/core/utils/index.js';
 
@@ -15,7 +15,7 @@
         icon?: string;
         sub_content?: unknown;
         text?: string;
-        on_click?: Any;
+        on_click?: Operations;
     }
 
     const itemClasses = cn(

--- a/src/lib/core/app/app.test.ts
+++ b/src/lib/core/app/app.test.ts
@@ -161,6 +161,123 @@ describe('App', () => {
         });
     });
 
+    describe('replaceSlot', () => {
+        it('should replace slot with body content in a simple layout', () => {
+            const layout = {
+                h1: 'Hello World',
+                slot: null,
+            };
+            const body = [{ type: 'p', text: 'Hello' }];
+
+            const result = app['replaceSlot'](layout, body);
+
+            expect(result).toEqual({
+                h1: 'Hello World',
+                slot: [{ type: 'p', text: 'Hello' }],
+            });
+        });
+
+        it('should replace slot in nested objects', () => {
+            const layout = {
+                type: 'div',
+                content: {
+                    type: 'section',
+                    children: {
+                        type: 'article',
+                        slot: null,
+                    },
+                },
+            };
+            const body = [{ type: 'p', text: 'Hello' }];
+
+            const result = app['replaceSlot'](layout, body);
+
+            expect(result).toEqual({
+                type: 'div',
+                content: {
+                    type: 'section',
+                    children: {
+                        type: 'article',
+                        slot: [{ type: 'p', text: 'Hello' }],
+                    },
+                },
+            });
+        });
+
+        it('should handle multiple slots in different nested levels', () => {
+            const layout = {
+                type: 'div',
+                slot: null,
+                content: {
+                    type: 'section',
+                    children: {
+                        type: 'article',
+                        slot: null,
+                    },
+                },
+            };
+            const body = [{ type: 'p', text: 'Hello' }];
+
+            const result = app['replaceSlot'](layout, body);
+
+            expect(result).toEqual({
+                type: 'div',
+                slot: [{ type: 'p', text: 'Hello' }],
+                content: {
+                    type: 'section',
+                    children: {
+                        type: 'article',
+                        slot: [{ type: 'p', text: 'Hello' }],
+                    },
+                },
+            });
+        });
+
+        it('should return body when layout is undefined', () => {
+            const body = [{ type: 'p', text: 'Hello' }];
+
+            const result = app['replaceSlot'](undefined, body);
+
+            expect(result).toEqual(body);
+        });
+
+        it('should ignore non-object values in layout', () => {
+            const layout = {
+                type: 'div',
+                slot: null,
+                content: 'string value',
+                number: 42,
+                bool: true,
+            };
+            const body = [{ type: 'p', text: 'Hello' }];
+
+            const result = app['replaceSlot'](layout, body);
+
+            expect(result).toEqual({
+                type: 'div',
+                slot: [{ type: 'p', text: 'Hello' }],
+                content: 'string value',
+                number: 42,
+                bool: true,
+            });
+        });
+
+        it('should keep null values in layout', () => {
+            const layout = { type: 'div', slot: null, content: null, number: null, bool: null };
+            const body = [{ type: 'p', text: 'Hello' }];
+
+            const result = app['replaceSlot'](layout, body);
+
+            expect(result).toEqual({
+                type: 'div',
+                slot: [{ type: 'p', text: 'Hello' }],
+                content: null,
+                number: null,
+                bool: null,
+            });
+        });
+    });
+
     describe('plug', () => {
         beforeEach(() => {
             app = createApp();

--- a/src/lib/core/app/index.ts
+++ b/src/lib/core/app/index.ts
@@ -207,7 +207,7 @@ export class Application {
                 continue;
             }
 
-            if (typeof value === 'object') {
+            if (value !== null && typeof value === 'object') {
                 layout[key] = this.replaceSlot(value, body);
             }
         }

--- a/src/lib/integrations/sveltekit.ts
+++ b/src/lib/integrations/sveltekit.ts
@@ -16,7 +16,72 @@ export function createProxyApiHandlers(apiUrl: string) {
         });
     };
 
-    return { GET };
+    const POST: RequestHandler = async ({ params, url, cookies, request }) => {
+        const headers: Record<string, string> = {
+            'Content-Type': 'application/json',
+        };
+        const authToken = cookies.get('auth_token');
+
+        if (authToken) headers['Authorization'] = `Bearer ${authToken}`;
+
+        const data = await request.json();
+
+        return fetch(`${apiUrl}${params.path + url.search}`, {
+            method: 'POST',
+            headers,
+            body: JSON.stringify(data),
+        });
+    };
+
+    const PUT: RequestHandler = async ({ params, url, cookies, request }) => {
+        const headers: Record<string, string> = {
+            'Content-Type': 'application/json',
+        };
+        const authToken = cookies.get('auth_token');
+
+        if (authToken) headers['Authorization'] = `Bearer ${authToken}`;
+
+        const data = await request.json();
+
+        return fetch(`${apiUrl}${params.path + url.search}`, {
+            method: 'PUT',
+            headers,
+            body: JSON.stringify(data),
+        });
+    };
+
+    const PATCH: RequestHandler = async ({ params, url, cookies, request }) => {
+        const headers: Record<string, string> = {
+            'Content-Type': 'application/json',
+        };
+        const authToken = cookies.get('auth_token');
+
+        if (authToken) headers['Authorization'] = `Bearer ${authToken}`;
+
+        const data = await request.json();
+
+        return fetch(`${apiUrl}${params.path + url.search}`, {
+            method: 'PATCH',
+            headers,
+            body: JSON.stringify(data),
+        });
+    };
+
+    const DELETE: RequestHandler = async ({ params, url, cookies }) => {
+        const headers: Record<string, string> = {
+            'Content-Type': 'application/json',
+        };
+        const authToken = cookies.get('auth_token');
+
+        if (authToken) headers['Authorization'] = `Bearer ${authToken}`;
+
+        return fetch(`${apiUrl}${params.path + url.search}`, {
+            method: 'DELETE',
+            headers,
+        });
+    };
+
+    return { GET, POST, PUT, PATCH, DELETE };
 }
 
 export const handle: Handle = async ({ event, resolve }) => {


### PR DESCRIPTION
- Add missing handlers for `POST`, `PUT`, `PATCH`, and `DELETE` to the sveltekit's `createProxyApiHandlers` method.
- Fix how app render was rendering layouts with null values on it. Any null value was being replaced by the body content of the page. Now this is fixed.